### PR TITLE
remove formatting per discussion

### DIFF
--- a/devs/changelog.mdx
+++ b/devs/changelog.mdx
@@ -2,20 +2,3 @@
 title: 'Changelog'
 description: "All notable changes to this project will be documented in this file."
 ---
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [Unreleased]
-
-## [0.1.0] - 2024-01-01
-### Added
-
-### Changed
-
-### Deprecated
-
-### Removed
-
-### Fixed
-
-### Security


### PR DESCRIPTION
This is relevant to the discussion we had on Wednesday about removing the official changelog format in favor of a looser structure more similar to incident.io 's changelog. 